### PR TITLE
Added a check when getting the boards catalog from 4chan

### DIFF
--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -67,17 +67,22 @@ def scan(keywords_file, output, log_file):
             folder_name = search["folder_name"]
             board = search["board"]
             keywords = search["keywords"]
+            try:
+                catalog_json = get_catalog_json(board)
 
-            catalog_json = get_catalog_json(board)
+                for keyword in keywords:
+                    threads_id = scan_thread(keyword, catalog_json)
 
-            for keyword in keywords:
-                threads_id = scan_thread(keyword, catalog_json)
-
-                dl_log = open("{0}/{1}".format(output, log_file)).read()
-                for thread_id in list(set(threads_id)):
-                    if str(thread_id) not in dl_log:
-                        download_thread(thread_id, board, folder_name, output)
-                        add_to_downloaded(thread_id, log_file, output)
+                    dl_log = open("{0}/{1}".format(output, log_file)).read()
+                    for thread_id in list(set(threads_id)):
+                        if str(thread_id) not in dl_log:
+                            download_thread(thread_id, board, folder_name,
+                                            output)
+                            add_to_downloaded(thread_id, log_file, output)
+            except requests.exceptions.HTTPError as err:
+                print("Error while opening {0} catalog page. "
+                      "Retrying during next scan.")
+                pass
 
         active_downloads = threading.active_count()-1
         print("{0} Threads download are active!".format(active_downloads))

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -81,7 +81,7 @@ def scan(keywords_file, output, log_file):
                             add_to_downloaded(thread_id, log_file, output)
             except requests.exceptions.HTTPError as err:
                 print("Error while opening {0} catalog page. "
-                      "Retrying during next scan.")
+                      "Retrying during next scan.".format(board))
                 pass
 
         active_downloads = threading.active_count()-1


### PR DESCRIPTION
The request to get the board catalog would sometime throw an exception and crash 4scanner. The try catch I added will detect the error and continue with the other searches. 4scanner will try getting the board catalog again during the next scan.