### PR TITLE
Error handling scanner

### DIFF
--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -8,6 +8,7 @@ from scanner import download, chan_info
 import subprocess
 import urllib.request
 import threading
+import httplib
 
 
 def get_catalog_json(board, chan):

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -14,7 +14,11 @@ def get_catalog_json(board, chan):
     chan_base_url = chan_info.get_chan_info(chan)[0]
     catalog = urllib.request.urlopen(
               "{0}{1}/catalog.json".format(chan_base_url, board))
-    return json.loads(catalog.read().decode("utf8"))
+    try:
+        catalog_data = catalog.read()
+    except httplib.IncompleteRead as err:
+        catalog_data = err.partial
+    return json.loads(catalog_data.decode("utf8"))
 
 
 def scan_thread(keyword, catalog_json):

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -8,7 +8,7 @@ from scanner import download, chan_info
 import subprocess
 import urllib.request
 import threading
-import httplib
+import http.client
 
 
 def get_catalog_json(board, chan):
@@ -17,7 +17,7 @@ def get_catalog_json(board, chan):
               "{0}{1}/catalog.json".format(chan_base_url, board))
     try:
         catalog_data = catalog.read()
-    except httplib.IncompleteRead as err:
+    except http.client.IncompleteRead as err:
         catalog_data = err.partial
     return json.loads(catalog_data.decode("utf8"))
 


### PR DESCRIPTION
Using the partial data read by `urllib` to resolve `IncompleteRead` error.The error is generally caused by server sending the data which doesn't send the Terminating string.But this edit won't detect when the connection is really closed in between but that has a very low probability. As most of the times error would be due to server which is not following the protocol.

Reference - [blog link](http://bobrochel.blogspot.in/2010/11/bad-servers-chunked-encoding-and.html?showComment=1358777800048)